### PR TITLE
Add missing method

### DIFF
--- a/util_windows.go
+++ b/util_windows.go
@@ -61,6 +61,32 @@ type State struct {
 	mode uint32
 }
 
+// VisualLength returns the number of visible glyphs in a string.  This can be
+// useful for getting the length of a string which has ANSI color sequences,
+// but it doesn't count "wide" glyphs differently than others, and it won't
+// handle ANSI cursor commands; e.g., it ignores "\x1b[D" rather than knowing
+// that the cursor position moved to the left.
+func VisualLength(s string) int {
+	runes := []rune(s)
+	inEscapeSeq := false
+	length := 0
+
+	for _, r := range runes {
+		switch {
+		case inEscapeSeq:
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') {
+				inEscapeSeq = false
+			}
+		case r == '\x1b':
+			inEscapeSeq = true
+		default:
+			length++
+		}
+	}
+
+	return length
+}
+
 // IsTerminal returns true if the given file descriptor is a terminal.
 func IsTerminal(fd int) bool {
 	var st uint32


### PR DESCRIPTION
The build is broken on windows without this method.

```
$ GOOS=windows GOARCH=amd64 go build
# github.com/Nerdmaster/terminal
../../Nerdmaster/terminal/absprompt.go:46: undefined: VisualLength
```
btw thank you for awesome package, just what I needed!